### PR TITLE
Add the Master React Playlist to the Full-Projects Videos section

### DIFF
--- a/topics/full-projects.md
+++ b/topics/full-projects.md
@@ -1,12 +1,12 @@
 # Full Projects
 
 :tv: Videos
-- 🌟🌟🌟 [Build and Deploy a React Cryptocurrency App and Master Redux Toolkit in One Video](https://www.youtube.com/watch?v=9DDX3US3kss)
-- 🌟🌟🌟 [Build and Deploy 5 JavaScript & React API Projects in 10 Hours](https://www.youtube.com/watch?v=GDa8kZLNhJ4)
+
+- 🌟🌟🌟 [Master React JS by Building Real Projects Playlist](https://www.youtube.com/watch?v=GDa8kZLNhJ4&list=PL6QREj8te1P6wX9m5KnicnDVEucbOPsqR&ab_channel=JavaScriptMastery)
 - 🌟🌟🌟🌟 [Build LinkedIn with React JS (Firebase + Styled Components + Redux)](https://www.youtube.com/watch?v=xP3cxbDUtrc)
 
 :movie_camera: Courses
+
 - 🌟🌟 [Udemy] [50 Projects In 50 Days - HTML, CSS & JavaScript!](https://www.udemy.com/course/50-projects-50-days/)
 
 :memo: Articles
-

--- a/topics/react-native.md
+++ b/topics/react-native.md
@@ -1,12 +1,16 @@
-
 # React Native
 
 :tv: Videos
-- 🌟🌟🌟 [React Native advanced animations](https://www.youtube.com/watch?v=6jxy5wfNpk0&list=PLkOyNuxGl9jxB_ARphTDoOWf5AE1J-x1r)
 
+- 🌟🌟🌟 [React Native advanced animations](https://www.youtube.com/watch?v=6jxy5wfNpk0&list=PLkOyNuxGl9jxB_ARphTDoOWf5AE1J-x1r)
 
 :movie_camera: Full projects
 
 - 🌟🌟🌟[React Native Fasion app](https://www.youtube.com/watch?v=UkG3kWTGhTE&list=PLkOyNuxGl9jyhndcnbFcgNM81fZak7Rbw)
+- 🌟🌟🌟[Instagram Clone with React Native](https://www.youtube.com/watch?v=UbixZZDjrdU)
+- 🌟🌟🌟[Uber with React Native](https://www.youtube.com/watch?v=bvn_HYpix6s)
+- 🌟🌟🌟[Tesla Clone with React Native](https://www.youtube.com/watch?v=y7-IG4SSI3E)
+- 🌟🌟🌟[Zoom Clone with React Native & NodeJS](https://www.youtube.com/watch?v=dHTGKB6tIQI)
+- 🌟🌟🌟[Uber Eats with React Native](https://www.youtube.com/watch?v=jmvbhuJXFow)
 
 :memo: Articles


### PR DESCRIPTION
Hi!

I have removed the first two videos of the **[full-projects.md](https://github.com/MRezaSafari/AwesomeFrontend/blob/main/topics/full-projects.md)** videos section and instead, add the full Master React playlist of the same instructor and youtube channel.

I think It is more concise and suitable.

on the other hand, we can link to each video of the playlist individually, if we want.